### PR TITLE
GH-68: Add Matter-Server and Matter-Bridge to Deployment

### DIFF
--- a/charts/eclipse-aiida/templates/core/deployment.yaml
+++ b/charts/eclipse-aiida/templates/core/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           image: {{ .Values.core.image.name }}:{{ .Values.core.image.version }}
           ports:
             - name: core
-              containerPort: 8080
+              containerPort: {{ .Values.core.ports.configurationApi }}
           env:
             - name: AIIDA_PUBLIC_URL
               value: "{{ include "eclipse-aiida.core.external-host" . }}"

--- a/charts/eclipse-aiida/templates/core/service.yaml
+++ b/charts/eclipse-aiida/templates/core/service.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - name: core
       targetPort: core
-      port: 8080
+      port: {{ .Values.core.ports.configurationApi }}
 {{- end }}

--- a/charts/eclipse-aiida/templates/matter-bridge/service.yaml
+++ b/charts/eclipse-aiida/templates/matter-bridge/service.yaml
@@ -1,0 +1,16 @@
+{{- if eq .Values.matter.enabled true }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-matter
+spec:
+  selector:
+    app: {{ .Release.Name }}-matter
+  ports:
+    - name: matter-server
+      port: {{ .Values.matter.server.ports.ws }}
+      targetPort: matter-server
+    - name: matter-bridge
+      port: {{ .Values.matter.bridge.ports.http }}
+      targetPort: matter-bridge
+{{- end }}

--- a/charts/eclipse-aiida/templates/matter-bridge/stateful-set.yaml
+++ b/charts/eclipse-aiida/templates/matter-bridge/stateful-set.yaml
@@ -1,0 +1,67 @@
+{{- if eq .Values.matter.enabled true }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-matter
+spec:
+  serviceName: {{ .Release.Name }}-matter
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-matter
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-matter
+    spec:
+      hostNetwork: true # <-- needed for mDNS discovery to work properly, otherwise, no Matter devices can be commissioned
+      containers:
+        - name: matter-server
+          image: {{ .Values.matter.server.image.name }}:{{ .Values.matter.server.image.version }}
+          ports:
+            - name: matter-server
+              containerPort: {{ .Values.matter.server.ports.ws }}
+          args:
+            - --storage-path
+            - {{ .Values.matter.server.storagePath }}
+            - --paa-root-cert-dir
+            - {{ .Values.matter.server.storagePath }}/credentials
+          volumeMounts:
+            - name: matter-server-data
+              mountPath: {{ .Values.matter.server.storagePath }}
+
+        - name: matter-bridge
+          image: {{ .Values.matter.bridge.image.name }}:{{ .Values.matter.bridge.image.version }}
+          ports:
+            - name: matter-bridge
+              containerPort: {{ .Values.matter.bridge.ports.http }}
+          env:
+            - name: DEVICE_STORAGE_PATH
+              value: {{ .Values.matter.bridge.deviceStoragePath }}
+            - name: MATTER_SERVER_URL
+              value: "ws://localhost:{{ .Values.matter.server.ports.ws }}/ws"
+            - name: AIIDA_API_URL
+              value: "http://{{ .Release.Name }}-core:{{ .Values.core.ports.configurationApi }}/api"
+          volumeMounts:
+            - name: matter-bridge-data
+              mountPath: {{ .Values.matter.bridge.deviceStoragePath }}
+
+      imagePullSecrets:
+        - name: {{ .Values.ghcrImagePullSecrets.name }}
+
+  volumeClaimTemplates:
+    - metadata:
+        name: matter-server-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.matter.server.storageSize }}
+    - metadata:
+        name: matter-bridge-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.matter.bridge.storageSize }}
+{{- end }}

--- a/charts/eclipse-aiida/values.yaml
+++ b/charts/eclipse-aiida/values.yaml
@@ -19,6 +19,8 @@ core:
   federator:
     url: "https://eclipse-dev.projekte.fh-hagenberg.at/federator"
   encryptedInstallerToken: ""
+  ports:
+    configurationApi: 8080
   loggingLevel:
     root:
     aiida:
@@ -75,3 +77,24 @@ external:
   encryptedMqttPassword: ""
   encryptedDashboardUsername: ""
   encryptedDashboardPassword: ""
+
+matter:
+  enabled: true
+  
+  server:
+    image:
+      name: ghcr.io/home-assistant-libs/python-matter-server
+      version: stable
+    storagePath: /matter-server-data
+    storageSize: 100Mi
+    ports:
+      ws: 5580
+
+  bridge:
+    image:
+      name: ghcr.io/eclipse-energy/eclipse-matter-bridge
+      version: latest
+    deviceStoragePath: /app/data/devices
+    storageSize: 100Mi
+    ports:
+      http: 8181


### PR DESCRIPTION
This PR adds necessary components for a Matter Datasource to the deployment. The two containers (matter-server and matter-bridge) are running inside one pod, as they are thightly coupled and should be scaled as one. The pod is running on the host network, as the matter-server needs to be on the host network to do mDNS discoveries to find the devices. A stateful set is used, as both components need to store data locally (mostly done in JSON files)